### PR TITLE
Fix CSV parsing regex and normalize parser tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,7 @@ import { HashRouter as Router, Routes, Route, Link, useNavigate } from "react-ro
 
 /**
  * 魚日報デモ（加工する魚原材料 / 魚原料在庫報告書）— デザイン刷新版（バグ修正＋UI強化）
- * - 正規表現修正: CSV分割を `text.split(/
-?
-/)` に統一
+ * - 正規表現修正: CSV分割を `text.split(/\r?\n/)` に統一
  * - ホーム画面: 月切替＋表形式、右上「仕入れを報告する」モーダル、行ごとの「在庫報告をする」
  * - Intake: 「目視確認 有毒魚」と「気づいたこと（有毒魚）」を同一ボックスに統合
  * - Inventory: 「加工状態（単一選択）」に変更、産地（業者）を選択式に変更
@@ -41,9 +39,7 @@ const fallbackMaster: Record<MasterKey, string[]> = {
 /** CSV文字列→ {id: 選択肢[]} へ変換（1行目=名称, 2行目=ID, 3行目以降=選択肢） */
 function parseMasterCsv(text: string): Partial<Record<MasterKey, string[]>> {
   const rows = text
-    .split(/
-?
-/)
+    .split(/\r?\n/)
     .map((r) => r.split(",").map((c) => c.trim()))
     .filter((r) => r.length > 0);
   const colCount = rows[0]?.length ?? 0;
@@ -82,8 +78,7 @@ function runParserTests() {
       "factory,person,species,origin",
       "A工場,佐藤,サバ,北海道（〇〇水産）",
       "B工場,鈴木,アジ,宮城県（△△商店）",
-    ].join("
-");
+    ].join("\n");
     const out = parseMasterCsv(sample);
     const t1 = arraysEqual(out.factory || [], ["A工場", "B工場"]);
     const t2 = arraysEqual(out.person || [], ["佐藤", "鈴木"]);
@@ -96,8 +91,7 @@ function runParserTests() {
       "factory,person,species,supplier,admin,ozone_person,origin",
       "第一工場,佐藤,サバ,〇〇水産,管理者A,佐藤,北海道（〇〇水産）",
       "第二工場,鈴木,アジ,△△商店,管理者B,鈴木,宮城県（△△商店）",
-    ].join("
-");
+    ].join("\n");
     const outAll = parseMasterCsv(sampleAll);
     const tAll1 = arraysEqual(outAll.factory || [], ["第一工場", "第二工場"]);
     const tAll2 = arraysEqual(outAll.person || [], ["佐藤", "鈴木"]);
@@ -114,8 +108,7 @@ function runParserTests() {
       "A工場,佐藤",
       "B工場,鈴木",
       "",
-    ].join("
-");
+    ].join("\r\n");
     const outCRLF = parseMasterCsv(sampleCRLF);
     const t5 = arraysEqual(outCRLF.factory || [], ["A工場", "B工場"]);
     const t6 = arraysEqual(outCRLF.person || [], ["佐藤", "鈴木"]);
@@ -129,8 +122,7 @@ function runParserTests() {
       "A工場,佐藤,サバ",
       "B工場,鈴木,アジ",
       "",
-    ].join("
-");
+    ].join("\n");
     const outBlank = parseMasterCsv(sampleWithBlanks);
     const t7 = arraysEqual(outBlank.factory || [], ["A工場", "B工場"]);
     const t8 = arraysEqual(outBlank.species || [], ["サバ", "アジ"]);
@@ -140,8 +132,7 @@ function runParserTests() {
     const t9 = Object.keys(outEmpty).length === 0;
 
     // 見出しのみ
-    const headersOnly = ["工場,担当者", "factory,person"].join("
-");
+    const headersOnly = ["工場,担当者", "factory,person"].join("\n");
     const outHead = parseMasterCsv(headersOnly);
     const t10 = Object.keys(outHead).length === 0;
 


### PR DESCRIPTION
## Summary
- update the CSV parsing comment and implementation to use a single-line `/\r?\n/` regex
- normalize runParserTests sample joins to use explicit newline escape sequences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3242759f08329af4ab1e29a280342